### PR TITLE
Remove colon if `labelOptions` is unset

### DIFF
--- a/src/components/PaginationTable.jsx
+++ b/src/components/PaginationTable.jsx
@@ -59,7 +59,7 @@ const PaginationTable = (props) => {
     totalItemsCount,
     pageSizeOptions = [10, 25, 50],
     showOptions = true,
-    labelOptions = "Items mostrados",
+    labelOptions = "Items mostrados:",
     colorScheme = "teal",
     showQuantity = false,
   } = props;
@@ -143,7 +143,7 @@ const PaginationTable = (props) => {
         <HStack w="40%">
           {showOptions && (
             <>
-              <Text fontSize="sm"> {labelOptions}: </Text>
+              <Text fontSize="sm"> {labelOptions} </Text>
               <Select
                 w="auto"
                 size="sm"


### PR DESCRIPTION
This pull request introduces a 'fix' to the `PaginationTable`'s behaviour when `labelOptions` is unset to by removing the extra colon `:` when it is set. 

Previous behaviour was to leave the colon in even if this field was unset meaning even if you set this field to nothing, you'd at least have a colon before the select dropdown. (See examples).

The only 'workaround' current is to set `showOptions` to false which unfortunately also removes the dropdown.

To maintain the current functionality if `labelOptions` isn't set I've placed the colon in with the default value for `labelOptions` and removed it from the `Text` component rendered in the `PaginationTable`.

Examples:

Before (`labelOptions` unset)

![image](https://github.com/user-attachments/assets/e2b6db84-17a2-4649-be28-12445a77bf32)

After (`labelOptions` unset)

![image](https://github.com/user-attachments/assets/60ab601e-edb7-4172-ab27-e992a2076669)
