### PR TITLE
Pull Request Build Checks

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -4,11 +4,13 @@
 name: Node.js Package
 
 on:
+  pull_request:
   release:
     types: [created]
 
 jobs:
   build:
+    if: ${{ github.event_name != 'release' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,6 +20,7 @@ jobs:
       - run: npm install
       - run: npm run build
   publish-npm:
+    if: ${{ github.event_name == 'release' }}
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +35,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.PUBLISH_NPM_TOKEN}}
   publish-gpr:
+    if: ${{ github.event_name == 'release' }}
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This pull request introduces build checks that occur on a pull request the allows for greater trust in pull requests not breaking the package. 

I've added the `pull_request` event into the existing action workflow file as opposed to making another action as it was already responsible for a build job however it only performed it on release which could lead to broken builds if a failure isn't picked up in review.

To solve the issue of other release jobs running on every pull request, I've added conditions to all jobs checking the intended event that triggered the workflow run, runs only what is defined by the condition. 

I'll look into some caching additions and other QoL changes in the future